### PR TITLE
bech32: Add DecodeUnsafe for bypassing checksum validation

### DIFF
--- a/bech32/example_test.go
+++ b/bech32/example_test.go
@@ -14,7 +14,7 @@ import (
 // This example demonstrates how to decode a bech32 encoded string.
 func ExampleDecode() {
 	encoded := "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx"
-	hrp, decoded, err := bech32.Decode(encoded)
+	hrp, decoded, err := bech32.Decode(encoded, bech32.MaxLengthBIP173)
 	if err != nil {
 		fmt.Println("Error:", err)
 	}


### PR DESCRIPTION
Fixes cosmos/cosmos-sdk#10025.